### PR TITLE
Set up code signing for macOS builds

### DIFF
--- a/.github/workflows/launcher-macos.yml
+++ b/.github/workflows/launcher-macos.yml
@@ -28,6 +28,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Set up the code signing certificate. This was copied from the example in
+      # https://docs.github.com/en/actions/use-cases-and-examples/deploying/installing-an-apple-certificate-on-macos-runners-for-xcode-development.
+      - name: Set up code signing
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Set up some useful variables.
+          CERTIFICATE_PATH=$RUNNER_TEMP/build.p12
+          PROVISION_PROFILE_PATH=$RUNNER_TEMP/build.provisionprofile
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          
+          # Import the signing certificate and provisioning profile from our secrets.
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PROVISION_PROFILE_PATH
+          
+          # Create a temporary keychain which will hold the signing certificate.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          
+          # Add the certificate to the keychain.
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          
+          # Apply the provisioning profile.
+          # This path is based on what I found at https://stackoverflow.com/questions/45625347/xcode-provisioning-profiles-location#45642752
+          mkdir -p ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+          cp $PROVISION_PROFILE_PATH ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+
       - name: Download Composer
         uses: robinraju/release-downloader@v1
         with:

--- a/.github/workflows/launcher-macos.yml
+++ b/.github/workflows/launcher-macos.yml
@@ -41,21 +41,21 @@ jobs:
           CERTIFICATE_PATH=$RUNNER_TEMP/build.p12
           PROVISION_PROFILE_PATH=$RUNNER_TEMP/build.provisionprofile
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          
+
           # Import the signing certificate and provisioning profile from our secrets.
           echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
           echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PROVISION_PROFILE_PATH
-          
+
           # Create a temporary keychain which will hold the signing certificate.
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          
+
           # Add the certificate to the keychain.
           security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
-          
+
           # Apply the provisioning profile.
           # This path is based on what I found at https://stackoverflow.com/questions/45625347/xcode-provisioning-profiles-location#45642752
           mkdir -p ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
@@ -88,6 +88,11 @@ jobs:
         run: npm clean-install
 
       - name: Create application bundle
+        env:
+          # @see forge.config.js
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APP_PASSWORD: ${{ secrets.APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run make
 
       - name: Delete PHP interpreter artifact

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,5 +1,17 @@
 const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
+const { APPLE_ID, APP_PASSWORD, APPLE_TEAM_ID } = process.env;
+
+let osxNotarize = null;
+if ( APPLE_ID && APP_PASSWORD && APPLE_TEAM_ID ) {
+  osxNotarize = {
+    appleId: APPLE_ID,
+    appleIdPassword: APP_PASSWORD,
+    teamId: APPLE_TEAM_ID,
+  };
+} else {
+  console.warn( 'Skipping macOS notarization.' );
+}
 
 module.exports = {
   packagerConfig: {
@@ -11,6 +23,8 @@ module.exports = {
     asar: false,
     icon: 'icon',
     name: 'Launch Drupal CMS',
+    osxNotarize,
+    osxSign: {},
   },
   rebuildConfig: {},
   makers: [


### PR DESCRIPTION
This is really hard to figure out.

But, with help from @hestenet and @drumm, and following the fine documentation from Electron, GitHub, and Apple, it works: https://github.com/drupal/cms-launcher/actions/runs/13167832419