### PR TITLE
ProcessFactory shouldn't assume that $command has anything in it

### DIFF
--- a/live_update/src/ProcessFactory.php
+++ b/live_update/src/ProcessFactory.php
@@ -20,7 +20,7 @@ final class ProcessFactory implements ProcessFactoryInterface {
   public function create(array $command, ?PathInterface $cwd = NULL, array $env = []): ProcessInterface {
     $command = array_map('trim', array_values($command));
 
-    if (PHP_SAPI === 'cli' || PHP_SAPI === 'cli-server' && str_ends_with($command[0], DIRECTORY_SEPARATOR . 'composer')) {
+    if ((PHP_SAPI === 'cli' || PHP_SAPI === 'cli-server') && $command && str_ends_with($command[0], DIRECTORY_SEPARATOR . 'composer')) {
       array_unshift($command, PHP_BINARY);
       $env['COMPOSER_HOME'] = dirname(PHP_BINARY, 2) . DIRECTORY_SEPARATOR . '.composer';
     }


### PR DESCRIPTION
Fixes #18.

I'll need @chrisfromredfin to manually test this, I think, but it should prevent whatever error condition caused that bug, from happening. 

How to test:

Download the appropriate artifact from https://github.com/drupal/cms-launcher/actions/runs/13185757722 (ARM64 = Apple silicon, X64 = Intel). Extract it and run the following to take it out of quarantine: `"sudo xattr -dr com.apple.quarantine /path/to/Launch Drupal CMS.app"`.