### PR TITLE
Skip permissions hardening by default

### DIFF
--- a/drupal-cms.js
+++ b/drupal-cms.js
@@ -43,6 +43,7 @@ module.exports = async ( dir, { php, composer }) => {
     await appendFile(
         localSettingsFile,
         `
+$settings['skip_permissions_hardening'] = TRUE;
 $settings['hash_salt'] = '${ randomBytes( 32 ).toString( 'hex' ) }';
 $settings['config_sync_directory'] = '${ path.join( dir, 'config' ) }';
 $config['package_manager.settings']['executables']['composer'] = '${composer}';`,

--- a/drupal-cms.js
+++ b/drupal-cms.js
@@ -43,7 +43,6 @@ module.exports = async ( dir, { php, composer }) => {
     await appendFile(
         localSettingsFile,
         `
-$settings['skip_permissions_hardening'] = TRUE;
 $settings['hash_salt'] = '${ randomBytes( 32 ).toString( 'hex' ) }';
 $settings['config_sync_directory'] = '${ path.join( dir, 'config' ) }';
 $config['package_manager.settings']['executables']['composer'] = '${composer}';`,

--- a/settings.local.php
+++ b/settings.local.php
@@ -7,3 +7,5 @@ $databases['default']['default'] = array (
   'namespace' => 'Drupal\\sqlite\\Driver\\Database\\sqlite',
   'autoload' => 'core/modules/sqlite/src/Driver/Database/sqlite/',
 );
+// Make it easier for Project Browser to install things into the local site.
+$settings['skip_permissions_hardening'] = TRUE;


### PR DESCRIPTION
This should fix #20.

How to test:

Download the appropriate artifact from https://github.com/drupal/cms-launcher/actions/runs/13187121616 (ARM64 = Apple silicon, X64 = Intel). Extract it and run the following to take it out of quarantine: `sudo xattr -dr com.apple.quarantine "/path/to/Launch Drupal CMS.app"`.