### PR TITLE
Specify the root package version to Composer so that it won't try to call unavailable command-line programs

### DIFF
--- a/.github/workflows/php-windows.yml
+++ b/.github/workflows/php-windows.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: crazywhalecc/static-php-cli
-          ref: 2.5.0
+          ref: 2.4.5
 
       - name: Generate cache key
         shell: bash

--- a/.github/workflows/php-windows.yml
+++ b/.github/workflows/php-windows.yml
@@ -9,6 +9,7 @@ env:
   PHP_EXTENSIONS: bz2,ctype,curl,dom,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sqlite3,tokenizer,xml,xmlwriter,yaml,zip,zlib
   PHP_LIBRARIES: libjpeg,libavif,freetype,libwebp
   PHP_VERSION: 8.3
+  WINBUILD_ACKNOWLEDGE_DEPRECATED: yes
 
 jobs:
   build:
@@ -18,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: crazywhalecc/static-php-cli
-          ref: 2.4.5
+          ref: 2.4.4
 
       - name: Generate cache key
         shell: bash

--- a/drupal-cms.js
+++ b/drupal-cms.js
@@ -22,7 +22,9 @@ module.exports = async ( dir, { php, composer }) => {
     // which would produce a disconcerting beach ball on macOS.
     await toPromise( execFile )(
         php,
-        [ composer, 'create-project', 'drupal/cms', dir ],
+        // Prefer dist installs so Composer won't try to run Git, which we can't
+        // rely on being installed.
+        [ composer, 'create-project', 'drupal/cms', '--prefer-install=dist', dir ],
         {
             // It should take less than 10 minutes to install Drupal CMS.
             timeout: 600000,

--- a/drupal-cms.js
+++ b/drupal-cms.js
@@ -46,11 +46,11 @@ module.exports = async ( dir, { php, composer }) => {
     // which might not be installed.
     await execFileAsPromise(
         php,
-        [ composer, 'config', 'extra.drupal-scaffold.gitignore', 'true', '--json', `--working-dir=${dir}` ],
+        [ composer, 'config', 'extra.drupal-scaffold.gitignore', 'false', '--json', `--working-dir=${dir}` ],
         { env },
     );
 
-    // Install dependencies. For faster spin-up, skip the security audit.
+    // Finally, install dependencies.
     await execFileAsPromise(
         php,
         [ composer, 'install', `--working-dir=${dir}` ],

--- a/drupal-cms.js
+++ b/drupal-cms.js
@@ -24,7 +24,7 @@ module.exports = async ( dir, { php, composer }) => {
         php,
         // Prefer dist installs so Composer won't try to run Git, which we can't
         // rely on being installed.
-        [ composer, 'create-project', 'drupal/cms', '--prefer-install=dist', dir ],
+        [ composer, 'create-project', 'drupal/cms', '--prefer-dist', dir ],
         {
             // It should take less than 10 minutes to install Drupal CMS.
             timeout: 600000,


### PR DESCRIPTION
Trying to get around #39.

To test this, once you download the app, you'll need to take it out of quarantine first because these development snapshots are not signed:

```
sudo xattr -dr com.apple.quarantine "/path/to/Launch Drupal CMS.app"
```