### PR TITLE
Disable signtool for Windows builds

### DIFF
--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Code signing
         uses: azure/trusted-signing-action@v0.5.1
-#        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -66,26 +66,10 @@ jobs:
         with:
           name: php-windows
 
-      - name: Sign PHP executable
-        uses: azure/trusted-signing-action@v0.5.1
-#        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: https://wus2.codesigning.azure.net/
-          trusted-signing-account-name: da-trusted-signing-001
-          certificate-profile-name: drupal-association-cert-profile
-          files-folder: "./bin"
-          files-folder-filter: exe,dll
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
       - name: Create application bundle
         run: yarn run make
 
-      - name: Sign application bundle
+      - name: Code signing
         uses: azure/trusted-signing-action@v0.5.1
 #        if: startsWith(github.ref, 'refs/tags/')
         with:
@@ -95,7 +79,7 @@ jobs:
           endpoint: https://wus2.codesigning.azure.net/
           trusted-signing-account-name: da-trusted-signing-001
           certificate-profile-name: drupal-association-cert-profile
-          files-folder: "./dist"
+          files-folder: "./dist/win-unpacked"
           files-folder-filter: exe,dll
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
@@ -105,5 +89,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-windows
-          path: './dist/*.exe'
+          path: './dist/win-unpacked'
           overwrite: true

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -61,13 +61,13 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
+      - name: Create application bundle
+        run: yarn run make
+
       - name: Delete PHP interpreter artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
           name: php-windows
-
-      - name: Create application bundle
-        run: yarn run make
 
       - name: Code signing
         uses: azure/trusted-signing-action@v0.5.1

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -61,42 +61,49 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
-      - name: Install NuGet
-        uses: nuget/setup-nuget@v2
-
-      - name: Create application bundle
-        env:
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        run: yarn run make
-
       - name: Delete PHP interpreter artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
           name: php-windows
 
-#      - name: Code signing
-#        uses: azure/trusted-signing-action@v0.5.1
+      - name: Sign PHP executable
+        uses: azure/trusted-signing-action@v0.5.1
 #        if: startsWith(github.ref, 'refs/tags/')
-#        with:
-#          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-#          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-#          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-#          endpoint: https://wus2.codesigning.azure.net/
-#          trusted-signing-account-name: da-trusted-signing-001
-#          certificate-profile-name: drupal-association-cert-profile
-#          files-folder: "./dist/win-unpacked"
-#          files-folder-filter: exe,dll
-#          # We also want to sign the PHP interpreter.
-#          files-folder-recurse: true
-#          file-digest: SHA256
-#          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-#          timestamp-digest: SHA256
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://wus2.codesigning.azure.net/
+          trusted-signing-account-name: da-trusted-signing-001
+          certificate-profile-name: drupal-association-cert-profile
+          files-folder: "./bin"
+          files-folder-filter: exe,dll
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Create application bundle
+        run: yarn run make
+
+      - name: Sign application bundle
+        uses: azure/trusted-signing-action@v0.5.1
+#        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://wus2.codesigning.azure.net/
+          trusted-signing-account-name: da-trusted-signing-001
+          certificate-profile-name: drupal-association-cert-profile
+          files-folder: "./dist"
+          files-folder-filter: exe,dll
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
           name: app-windows
-          path: './dist/win-unpacked'
+          path: './dist/*.exe'
           overwrite: true

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -61,7 +61,16 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
+      - name: Install NuGet
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -NonInteractive -Command Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser
+
       - name: Create application bundle
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: yarn run make
 
       - name: Delete PHP interpreter artifacts
@@ -69,23 +78,23 @@ jobs:
         with:
           name: php-windows
 
-      - name: Code signing
-        uses: azure/trusted-signing-action@v0.5.1
+#      - name: Code signing
+#        uses: azure/trusted-signing-action@v0.5.1
 #        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: https://wus2.codesigning.azure.net/
-          trusted-signing-account-name: da-trusted-signing-001
-          certificate-profile-name: drupal-association-cert-profile
-          files-folder: "./dist/win-unpacked"
-          files-folder-filter: exe,dll
-          # We also want to sign the PHP interpreter.
-          files-folder-recurse: true
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+#        with:
+#          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+#          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+#          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+#          endpoint: https://wus2.codesigning.azure.net/
+#          trusted-signing-account-name: da-trusted-signing-001
+#          certificate-profile-name: drupal-association-cert-profile
+#          files-folder: "./dist/win-unpacked"
+#          files-folder-filter: exe,dll
+#          # We also want to sign the PHP interpreter.
+#          files-folder-recurse: true
+#          file-digest: SHA256
+#          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+#          timestamp-digest: SHA256
 
       - name: Upload archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Code signing
         uses: azure/trusted-signing-action@v0.5.1
-        # if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -79,7 +79,7 @@ jobs:
           endpoint: https://wus2.codesigning.azure.net/
           trusted-signing-account-name: da-trusted-signing-001
           certificate-profile-name: drupal-association-cert-profile
-          files-folder: "./dist"
+          files-folder: "./dist/win-unpacked"
           files-folder-filter: exe,dll
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
@@ -89,7 +89,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-windows
-          path: './dist/*.exe'
-          # The executable is already compressed.
-          compression-level: 0
+          path: './dist/win-unpacked'
           overwrite: true

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -62,9 +62,7 @@ jobs:
         run: yarn install
 
       - name: Install NuGet
-        shell: pwsh
-        run: |
-          pwsh -NoProfile -NonInteractive -Command Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser
+        uses: nuget/setup-nuget@v2
 
       - name: Create application bundle
         env:

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Code signing
         uses: azure/trusted-signing-action@v0.5.1
-        if: startsWith(github.ref, 'refs/tags/')
+#        if: startsWith(github.ref, 'refs/tags/')
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -81,6 +81,7 @@ jobs:
           certificate-profile-name: drupal-association-cert-profile
           files-folder: "./dist/win-unpacked"
           files-folder-filter: exe,dll
+          files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -81,6 +81,8 @@ jobs:
           certificate-profile-name: drupal-association-cert-profile
           files-folder: "./dist/win-unpacked"
           files-folder-filter: exe,dll
+          # We also want to sign the PHP interpreter.
+          files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -62,10 +62,6 @@ jobs:
         run: yarn install
 
       - name: Create application bundle
-        env:
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: yarn run make
 
       - name: Delete PHP interpreter artifacts
@@ -75,7 +71,7 @@ jobs:
 
       - name: Code signing
         uses: azure/trusted-signing-action@v0.5.1
-        if: startsWith(github.ref, 'refs/tags/')
+        # if: startsWith(github.ref, 'refs/tags/')
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: app-windows
-          path: win
+          path: "Drupal CMS"
 
       - name: Download app for Linux (arm64)
         uses: actions/download-artifact@v4
@@ -65,7 +65,7 @@ jobs:
         run: |
           mv "./mac-arm64/Launch Drupal CMS-$VERSION-arm64.dmg" "Drupal CMS (macOS Apple silicon).dmg"
           mv "./mac-x64/Launch Drupal CMS-$VERSION-x64.dmg" "Drupal CMS (macOS Intel).dmg"
-          mv "./win/Launch Drupal CMS-$VERSION.exe" "Drupal CMS.exe"
+          zip -q -r "Drupal CMS (Windows).zip" "Drupal CMS"
           mv "./linux-arm64/Launch Drupal CMS-$VERSION-arm64.AppImage" "Drupal CMS (Linux arm64).AppImage"
           mv "./linux-x64/Launch Drupal CMS-$VERSION-x64.AppImage" "Drupal CMS (Linux x64).AppImage"
 
@@ -100,6 +100,6 @@ jobs:
           files: |
             Drupal CMS (macOS Apple silicon).dmg
             Drupal CMS (macOS Intel).dmg
-            Drupal CMS.exe
+            Drupal CMS (Windows).zip
             Drupal CMS (Linux arm64).AppImage
             Drupal CMS (Linux x64).AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: app-windows
-          path: "Drupal CMS"
+          path: win
 
       - name: Download app for Linux (arm64)
         uses: actions/download-artifact@v4
@@ -65,7 +65,7 @@ jobs:
         run: |
           mv "./mac-arm64/Launch Drupal CMS-$VERSION-arm64.dmg" "Drupal CMS (macOS Apple silicon).dmg"
           mv "./mac-x64/Launch Drupal CMS-$VERSION-x64.dmg" "Drupal CMS (macOS Intel).dmg"
-          zip -q -r "Drupal CMS (Windows).zip" "Drupal CMS"
+          mv "./win/Launch Drupal CMS-$VERSION.exe" "Drupal CMS.exe"
           mv "./linux-arm64/Launch Drupal CMS-$VERSION-arm64.AppImage" "Drupal CMS (Linux arm64).AppImage"
           mv "./linux-x64/Launch Drupal CMS-$VERSION-x64.AppImage" "Drupal CMS (Linux x64).AppImage"
 
@@ -100,6 +100,6 @@ jobs:
           files: |
             Drupal CMS (macOS Apple silicon).dmg
             Drupal CMS (macOS Intel).dmg
-            Drupal CMS (Windows).zip
+            Drupal CMS.exe
             Drupal CMS (Linux arm64).AppImage
             Drupal CMS (Linux x64).AppImage

--- a/build/disable-signtool.js
+++ b/build/disable-signtool.js
@@ -1,0 +1,5 @@
+export default async function ()
+{
+    // Do nothing; signing is handled by its own build step on GitHub Actions.
+    // @see .github/workflows/app-windows.yml
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -40,8 +40,9 @@ mac:
 productName: 'Launch Drupal CMS'
 
 win:
-  # Signing is done separately, for tagged releases on CI only.
-  # @see .github/workflows/launcher-windows.yml
-  signAndEditExecutable: false
+  # Signing is done in its own build step, for tagged releases on CI only.
+  # @see .github/workflows/app-windows.yml
+  signtoolOptions:
+    sign: './build/disable-signtool.js'
   # On Windows, build a portable app that doesn't require installation.
   target: portable

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,6 +42,8 @@ productName: 'Launch Drupal CMS'
 win:
   artifactName: '${productName}.${ext}'
   signtoolOptions:
+    # We use Azure Trusted Signing as a separate step on CI.
+    # @see .github/workflows/app-windows.yml
     sign: './build/disable-signtool.js'
   # On Windows, build a portable app that doesn't require installation.
   target: portable

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -40,6 +40,7 @@ mac:
 productName: 'Launch Drupal CMS'
 
 win:
+  artifactName: '${productName}.${ext}'
   # Signing is done in its own build step, for tagged releases on CI only.
   # @see .github/workflows/app-windows.yml
   signtoolOptions:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -41,9 +41,10 @@ productName: 'Launch Drupal CMS'
 
 win:
   artifactName: '${productName}.${ext}'
-  # Signing is done in its own build step, for tagged releases on CI only.
-  # @see .github/workflows/app-windows.yml
-  signtoolOptions:
-    sign: './build/disable-signtool.js'
+  azureSignOptions:
+    certificateProfileName: drupal-association-cert-profile
+    codeSigningAccountName: da-trusted-signing-001
+    endpoint: https://wus2.codesigning.azure.net/
+    publisherName: Drupal Association
   # On Windows, build a portable app that doesn't require installation.
   target: portable

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -41,10 +41,7 @@ productName: 'Launch Drupal CMS'
 
 win:
   artifactName: '${productName}.${ext}'
-  azureSignOptions:
-    certificateProfileName: drupal-association-cert-profile
-    codeSigningAccountName: da-trusted-signing-001
-    endpoint: https://wus2.codesigning.azure.net/
-    publisherName: Drupal Association
+  signtoolOptions:
+    sign: './build/disable-signtool.js'
   # On Windows, build a portable app that doesn't require installation.
   target: portable


### PR DESCRIPTION
We want code signing to only be done by Azure Trusted Signing. In theory, Electron Builder supports this, but it fails with some very strange bug in practice (see https://github.com/electron-userland/electron-builder/issues/9065).

Electron Builder doesn't appear to have any way to disable signing outright, but maybe we can just use a custom function to bypass `signtool`.