### PR TITLE
Always set `php` executable permissions to 755 on non-Windows platforms

### DIFF
--- a/binaries.js
+++ b/binaries.js
@@ -1,12 +1,18 @@
 const { execFileSync } = require( 'node:child_process' );
-const { access } = require( 'node:fs/promises' );
+const { access, chmod } = require( 'node:fs/promises' );
 const path = require( 'node:path' );
 
 const binDir = path.join( __dirname, 'bin' );
 const php = path.join( binDir, 'php' );
 
 module.exports = {
-    php,
+    async php () {
+        // On non-Windows machines, always ensure the PHP binary is executable.
+        if ( process.platform !== 'win32' ) {
+            await chmod( php, 0o755 );
+        }
+        return php;
+    },
     async composer () {
         // We need an unpacked version of Composer because the phar file has a shebang line
         // that breaks us, due to the fact that GUI-launched Electron apps don't inherit the

--- a/installer.js
+++ b/installer.js
@@ -12,7 +12,7 @@ module.exports = async ( dir, handler, win ) => {
         win?.send( 'install-start' );
 
         await handler( dir, {
-            php,
+            php: await php(),
             composer: await composer(),
         } );
     }

--- a/php-server.js
+++ b/php-server.js
@@ -29,7 +29,7 @@ module.exports = async ( dir, win ) => {
 
     // Start the built-in PHP web server.
     const process = execFile(
-        php,
+        await php(),
         [
             // Explicitly pass the cURL CA bundle so that HTTPS requests from Drupal can
             // succeed on Windows.


### PR DESCRIPTION
Tries to fix #56.