### PR TITLE
Unpack Composer as part of the build process

### DIFF
--- a/.github/workflows/app-linux.yml
+++ b/.github/workflows/app-linux.yml
@@ -28,23 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Composer
-        uses: robinraju/release-downloader@v1
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
-          repository: composer/composer
-          latest: true
-          fileName: composer.phar
-          out-file-path: bin
-
-      - name: Download PHP interpreter
-        uses: actions/download-artifact@v4
-        with:
-          name: php-linux-${{ runner.arch }}
-
-      - name: Prepare binaries
-        run: |
-          chmod +x php
-          mv php bin
+          tools: composer
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -67,8 +54,21 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
+      - name: Download PHP interpreter
+        uses: actions/download-artifact@v4
+        with:
+          name: php-linux-${{ runner.arch }}
+
       - name: Create application bundle
-        run: yarn run make
+        run: |
+          mkdir -p bin
+          chmod +x php
+          mv php bin
+          cd bin
+          cp $(which composer) composer.phar
+          phar extract -f composer.phar ./composer
+          rm composer.phar
+          yarn run make
 
       - name: Delete PHP interpreter artifact
         uses: geekyeggo/delete-artifact@v5

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -101,8 +101,10 @@ jobs:
       - name: Unpack Composer
         working-directory: bin
         run: |
-          which composer
-          which phar
+          cp $(which composer) composer.phar
+          phar extract -f composer.phar
+          rm composer.phar
+          ls -lR
 
       # Only notarize tagged releases; Electron Builder skips notarization if
       # these environment variables are undefined.

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -61,23 +61,10 @@ jobs:
           mkdir -p ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
           cp $PROVISION_PROFILE_PATH ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
-      - name: Download Composer
-        uses: robinraju/release-downloader@v1
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
-          repository: composer/composer
-          latest: true
-          fileName: composer.phar
-          out-file-path: bin
-
-      - name: Download PHP interpreter
-        uses: actions/download-artifact@v4
-        with:
-          name: php-macos
-
-      - name: Prepare binaries
-        run: |
-          chmod +x php
-          mv php bin
+          tools: composer
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -99,6 +86,23 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
+
+      - name: Download PHP interpreter
+        uses: actions/download-artifact@v4
+        with:
+          name: php-macos
+
+      - name: Prepare binaries
+        run: |
+          mkdir -p bin
+          chmod +x php
+          mv php bin
+
+      - name: Unpack Composer
+        working-directory: bin
+        run: |
+          which composer
+          which phar
 
       # Only notarize tagged releases; Electron Builder skips notarization if
       # these environment variables are undefined.

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -92,19 +92,6 @@ jobs:
         with:
           name: php-macos
 
-      - name: Prepare binaries
-        run: |
-          mkdir -p bin
-          chmod +x php
-          mv php bin
-
-      - name: Unpack Composer
-        working-directory: bin
-        run: |
-          cp $(which composer) composer.phar
-          phar extract -f composer.phar ./composer
-          rm composer.phar
-
       # Only notarize tagged releases; Electron Builder skips notarization if
       # these environment variables are undefined.
       - name: Enable notarization for tagged release
@@ -115,7 +102,15 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
 
       - name: Create application bundle
-        run: yarn run make
+        run: |
+          mkdir -p bin
+          chmod +x php
+          mv php bin
+          cd bin
+          cp $(which composer) composer.phar
+          phar extract -f composer.phar ./composer
+          rm composer.phar
+          yarn run make
 
       - name: Delete PHP interpreter artifact
         uses: geekyeggo/delete-artifact@v5

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -102,9 +102,8 @@ jobs:
         working-directory: bin
         run: |
           cp $(which composer) composer.phar
-          phar extract -f composer.phar
+          phar extract -f composer.phar ./composer
           rm composer.phar
-          ls -lR
 
       # Only notarize tagged releases; Electron Builder skips notarization if
       # these environment variables are undefined.

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -23,22 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Composer
-        uses: robinraju/release-downloader@v1
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
-          repository: composer/composer
-          latest: true
-          fileName: composer.phar
-          out-file-path: bin
-
-      - name: Download PHP interpreter
-        uses: actions/download-artifact@v4
-        with:
-          name: php-windows
-
-      - name: Prepare binaries
-        shell: bash
-        run: mv php.exe bin
+          tools: composer
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -61,8 +49,22 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
+      - name: Download PHP interpreter
+        uses: actions/download-artifact@v4
+        with:
+          name: php-windows
+
       - name: Create application bundle
-        run: yarn run make
+        shell: bash
+        run: |
+          mkdir -p bin
+          mv php.exe bin
+          cd bin
+          cp $(which composer) composer.phar
+          phar extract -f composer.phar ./composer
+          rm composer.phar
+          ls -lR
+          yarn run make
 
       - name: Delete PHP interpreter artifacts
         uses: geekyeggo/delete-artifact@v5

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Create application bundle
         shell: bash
         run: |
+          which php
           mkdir -p bin
           mv php.exe bin
           cd bin

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create application bundle
         shell: bash
         run: |
-          which php
+          ls /c/tools/php
           mkdir -p bin
           mv php.exe bin
           cd bin

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -57,12 +57,11 @@ jobs:
       - name: Create application bundle
         shell: bash
         run: |
-          ls /c/tools/php
           mkdir -p bin
           mv php.exe bin
           cd bin
           cp $(which composer) composer.phar
-          phar extract -f composer.phar ./composer
+          php.exe /c/tools/php/pharcommand.phar extract -f composer.phar ./composer
           rm composer.phar
           ls -lR
           yarn run make

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -63,7 +63,6 @@ jobs:
           cp $(which composer) composer.phar
           php.exe /c/tools/php/pharcommand.phar extract -f composer.phar ./composer
           rm composer.phar
-          ls -lR
           yarn run make
 
       - name: Delete PHP interpreter artifacts

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ Clone this repository, then `cd` into it and run:
 ```shell
 mkdir bin
 ln -s -f $(which php) bin
-ln -s -f $(which composer) bin/composer.phar
+cd bin
+cp $(which composer) composer.phar
+phar extract -f composer.phar ./composer
+cd ..
 yarn install
 yarn run start
 ```

--- a/binaries.js
+++ b/binaries.js
@@ -1,31 +1,13 @@
-const { execFileSync } = require( 'node:child_process' );
-const { access } = require( 'node:fs/promises' );
 const path = require( 'node:path' );
 
 const binDir = path.join( __dirname, 'bin' );
 const php = path.join( binDir, 'php' );
+// We use an unpacked version of Composer because the phar file has a shebang
+// line that breaks us, due to the fact that GUI-launched Electron apps don't
+// inherit the parent environment in macOS and Linux.
+const composer = path.join( binDir, 'composer', 'bin', 'composer' );
 
 module.exports = {
     php,
-    async composer () {
-        // We need an unpacked version of Composer because the phar file has a shebang line
-        // that breaks us, due to the fact that GUI-launched Electron apps don't inherit the
-        // parent environment in macOS and Linux. Instead, we extract Composer's executable
-        // sources from the phar file and point the PHP interpreter at them.
-        const composer = path.join( binDir, 'composer', 'bin', 'composer' );
-        try {
-            await access( composer );
-        } catch {
-            execFileSync(
-                php,
-                [ '-r', `(new Phar("composer.phar"))->extractTo("composer");` ],
-                {
-                    cwd: binDir,
-                    // This is an extremely generous timeout and should not be increased.
-                    timeout: 30000,
-                },
-            );
-        }
-        return composer;
-    },
+    composer,
 };

--- a/drupal-cms.js
+++ b/drupal-cms.js
@@ -17,7 +17,7 @@ const {
     stringify: toYAML,
 } = require( 'yaml' );
 
-module.exports = async ( dir, { php, composer }) => {
+module.exports = async ( dir, { php, composer } ) => {
     // Send a customized copy of the current environment variables to Composer.
     const env = Object.assign( {}, process.env );
     // Set COMPOSER_ROOT_VERSION so that Composer won't try to guess the root

--- a/installer.js
+++ b/installer.js
@@ -10,11 +10,7 @@ module.exports = async ( dir, handler, win ) => {
     } catch {
         // Let the renderer know we're about to install Drupal.
         win?.send( 'install-start' );
-
-        await handler( dir, {
-            php,
-            composer: await composer(),
-        } );
+        await handler( dir, { php, composer } );
     }
     win?.send( 'installed' );
 };


### PR DESCRIPTION
The Linux version doesn't work because it tries to extract Composer into the app resources, which are read-only (this is a design choice of AppImage).

In general, it would be better to unpack during the build process, both for performance and simplicity. This PR does exactly that. I have tested it on my Mac, and it worked fine; the Windows ZIP looks correct. The Linux version isn't officially supported yet, so I'll merge this and ask folks to test.