### PR TITLE
Install Composer into the project as a dev dependency, rather than forcing Drupal to rely on the app's bundled copy

### DIFF
--- a/installer.js
+++ b/installer.js
@@ -60,6 +60,16 @@ async function createProject ( win )
             env,
         },
     );
+    // Require Composer as a dev dependency so that Package Manager can use it
+    // without relying on this app.
+    await execAndStreamOutput(
+        php,
+        [ composer, 'require', '--dev', '--no-update', 'composer/composer' ],
+        {
+            cwd: projectRoot,
+            env,
+        },
+    );
     // Finally, install dependencies. We suppress the progress bar because it
     // looks lame when streamed to the renderer.
     await execAndStreamOutput(
@@ -89,8 +99,7 @@ async function createProject ( win )
         localSettingsFile,
         `
 $settings['hash_salt'] = '${ randomBytes( 32 ).toString( 'hex' ) }';
-$settings['config_sync_directory'] = '${ path.join( projectRoot, 'config' ) }';
-$config['package_manager.settings']['executables']['composer'] = '${composer}';`,
+$settings['config_sync_directory'] = '${ path.join( projectRoot, 'config' ) }';`
     );
     // Make sure we load the local settings if using the built-in web server.
     await appendFile(

--- a/settings.local.php
+++ b/settings.local.php
@@ -1,5 +1,7 @@
 <?php
 
+use Composer\InstalledVersions;
+
 $databases['default']['default'] = array (
   'prefix' => '',
   'database' => 'sites/default/files/.ht.sqlite',
@@ -12,6 +14,18 @@ $settings['skip_permissions_hardening'] = TRUE;
 
 // Allow use of the direct-write mode added to Package Manager in Drupal 11.2.
 $settings['package_manager_allow_direct_write'] = TRUE;
+
+// Use a copy of Composer that is locally installed in the project.
+try {
+  $config['package_manager.settings']['executables']['composer'] = InstalledVersions::getInstallPath('composer/composer') . '/bin/composer';
+}
+catch (OutOfBoundsException) {
+  // Can't figure out where Composer is, so don't try to configure it here.
+}
+
+// Allow `localhost` as a trusted host pattern to prevent an error on the status
+// report.
+$settings['trusted_host_patterns'][] = '^localhost$';
 
 // Suppress the warning raised by `skip_permissions_hardening`.
 // @see drupal_cms_installer_install_tasks()


### PR DESCRIPTION
Set the composer path inside the APPDIR environment variable path. 
Fixes #63 
(for linux)