### PR TITLE
Temporarily disable dependency caching on CI to work around a bug in npm

### DIFF
--- a/.github/workflows/app-linux.yml
+++ b/.github/workflows/app-linux.yml
@@ -43,6 +43,7 @@ jobs:
           corepack enable
           yarn set version berry
 
+# Dependency caching is temporarily disabled due to https://github.com/npm/cli/issues/4828.
 #      - name: Cache dependencies
 #        id: cache
 #        uses: actions/cache@v4

--- a/.github/workflows/app-linux.yml
+++ b/.github/workflows/app-linux.yml
@@ -43,15 +43,15 @@ jobs:
           corepack enable
           yarn set version berry
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+#      - name: Cache dependencies
+#        id: cache
+#        uses: actions/cache@v4
+#        with:
+#          path: node_modules
+#          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+#        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
       - name: Download PHP interpreter

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -76,15 +76,15 @@ jobs:
           corepack enable
           yarn set version berry
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+#      - name: Cache dependencies
+#        id: cache
+#        uses: actions/cache@v4
+#        with:
+#          path: node_modules
+#          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+#        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
       - name: Download PHP interpreter

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -76,6 +76,7 @@ jobs:
           corepack enable
           yarn set version berry
 
+# Dependency caching is temporarily disabled due to https://github.com/npm/cli/issues/4828.
 #      - name: Cache dependencies
 #        id: cache
 #        uses: actions/cache@v4

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -38,6 +38,7 @@ jobs:
           corepack enable
           yarn set version berry
 
+# Dependency caching is temporarily disabled due to https://github.com/npm/cli/issues/4828.
 #      - name: Cache dependencies
 #        id: cache
 #        uses: actions/cache@v4

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -38,15 +38,15 @@ jobs:
           corepack enable
           yarn set version berry
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+#      - name: Cache dependencies
+#        id: cache
+#        uses: actions/cache@v4
+#        with:
+#          path: node_modules
+#          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+#        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
       - name: Download PHP interpreter


### PR DESCRIPTION
We are being broken by https://github.com/npm/cli/issues/4828.