### PR TITLE
If an error occurs, surface it to the user

### DIFF
--- a/src/Drupal.ts
+++ b/src/Drupal.ts
@@ -1,4 +1,24 @@
-export default interface Drupal
+export enum Events
+{
+    InstallStarted = 'drupal-will-install',
+
+    InstallFinished = 'drupal-is-installed',
+
+    Output = 'drupal-output',
+
+    Started = 'drupal-is-started',
+
+    Error = 'drupal-error',
+}
+
+export enum Commands
+{
+    Start = 'drupal-start',
+
+    Open = 'drupal-open',
+}
+
+export interface Drupal
 {
     start: () => void;
 

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -1,4 +1,5 @@
 import { projectRoot, bin } from './config';
+import { Events } from "../Drupal";
 import { WebContents } from 'electron';
 import { access, copyFile, appendFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
@@ -15,7 +16,7 @@ const execFileAsPromise = toPromise( execFile );
 async function createProject ( win?: WebContents ): Promise<void>
 {
     // Let the renderer know we're about to install Drupal.
-    win?.send( 'install-started' );
+    win?.send( Events.InstallStarted );
 
     const { php, composer } = bin;
 
@@ -38,7 +39,7 @@ async function createProject ( win?: WebContents ): Promise<void>
         // if we don't have a valid stderr stream.
         readline.createInterface( task.child.stderr! )
             .on( 'line', ( line ) => {
-                win?.send( 'output', line );
+                win?.send( Events.Output, line );
             });
 
         return task;
@@ -115,5 +116,5 @@ export default async ( win?: WebContents ): Promise<void> => {
     } catch {
         await createProject( win );
     }
-    win?.send( 'install-finished' );
+    win?.send( Events.InstallFinished );
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,23 +1,24 @@
+import { Commands, Events } from "../Drupal";
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import install from './installer';
 import path from 'node:path';
 import startServer from './php-server';
 
-ipcMain.handle( 'start', async ({ sender: win }): Promise<void> => {
+ipcMain.handle( Commands.Start, async ({ sender: win }): Promise<void> => {
     try {
         await install( win );
 
         const { url, serverProcess } = await startServer();
         app.on( 'will-quit', () => serverProcess.kill() );
 
-        win.send( 'started', url );
+        win.send( Events.Started, url );
     }
     catch ( e ) {
-        win.send( 'error', e );
+        win.send( Events.Error, e );
     }
 } );
 
-ipcMain.handle( 'open', ( undefined, url: string ): void => {
+ipcMain.handle( Commands.Open, ( undefined, url: string ): void => {
     shell.openExternal( url );
 } );
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,13 +3,18 @@ import install from './installer';
 import path from 'node:path';
 import startServer from './php-server';
 
-ipcMain.handle( 'start', async ({ sender: win }): Promise<string> => {
-    await install( win );
+ipcMain.handle( 'start', async ({ sender: win }): Promise<void> => {
+    try {
+        await install( win );
 
-    const { url, serverProcess } = await startServer();
-    app.on( 'will-quit', () => serverProcess.kill() );
+        const { url, serverProcess } = await startServer();
+        app.on( 'will-quit', () => serverProcess.kill() );
 
-    return url;
+        win.send( 'started', url );
+    }
+    catch ( e ) {
+        win.send( 'error', e );
+    }
 } );
 
 ipcMain.handle( 'open', ( undefined, url: string ): void => {

--- a/src/preload/Drupal.ts
+++ b/src/preload/Drupal.ts
@@ -1,6 +1,6 @@
 export default interface Drupal
 {
-    start: () => Promise<string>;
+    start: () => void;
 
     open: ( url: string ) => void;
 
@@ -9,4 +9,8 @@ export default interface Drupal
     onInstallFinished: ( callback: () => void ) => void;
 
     onOutput: ( callback: ( line: string ) => void ) => void;
+
+    onStart: ( callback: ( url: string ) => void ) => void;
+
+    onError: ( callback: ( message: string ) => void ) => void;
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -3,8 +3,8 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld( 'drupal', {
 
-    start: (): Promise<string> => {
-        return ipcRenderer.invoke( 'start' );
+    start: (): void => {
+        ipcRenderer.invoke( 'start' );
     },
 
     open: ( url: string ): void => {
@@ -20,7 +20,15 @@ contextBridge.exposeInMainWorld( 'drupal', {
     },
 
     onOutput: ( callback: ( line: string ) => void ): void => {
-        ipcRenderer.on( 'output', ( undefined, line ) => callback( line ) );
+        ipcRenderer.on( 'output', ( undefined, line ): void => callback( line ) );
+    },
+
+    onStart: ( callback: ( url: string ) => void ): void => {
+        ipcRenderer.on( 'started', ( undefined, url ): void => callback( url ) );
+    },
+
+    onError: ( callback: ( message: string ) => void ): void => {
+        ipcRenderer.on( 'error', ( undefined, message ): void => callback( message ) );
     },
 
 } as Drupal );

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,34 +1,34 @@
-import Drupal from './Drupal';
+import { Commands, Drupal, Events } from '../Drupal';
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld( 'drupal', {
 
     start: (): void => {
-        ipcRenderer.invoke( 'start' );
+        ipcRenderer.invoke( Commands.Start );
     },
 
     open: ( url: string ): void => {
-        ipcRenderer.invoke( 'open', url );
+        ipcRenderer.invoke( Commands.Open, url );
     },
 
     onInstallStarted: ( callback: () => void ): void => {
-        ipcRenderer.on( 'install-started', () => callback() );
+        ipcRenderer.on( Events.InstallStarted, () => callback() );
     },
 
     onInstallFinished: ( callback: () => void ): void => {
-        ipcRenderer.on( 'install-finished', () => callback() );
+        ipcRenderer.on( Events.InstallFinished, () => callback() );
     },
 
     onOutput: ( callback: ( line: string ) => void ): void => {
-        ipcRenderer.on( 'output', ( undefined, line ): void => callback( line ) );
+        ipcRenderer.on( Events.Output, ( undefined, line ): void => callback( line ) );
     },
 
     onStart: ( callback: ( url: string ) => void ): void => {
-        ipcRenderer.on( 'started', ( undefined, url ): void => callback( url ) );
+        ipcRenderer.on( Events.Started, ( undefined, url ): void => callback( url ) );
     },
 
     onError: ( callback: ( message: string ) => void ): void => {
-        ipcRenderer.on( 'error', ( undefined, message ): void => callback( message ) );
+        ipcRenderer.on( Events.Error, ( undefined, message ): void => callback( message ) );
     },
 
 } as Drupal );

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -9,13 +9,13 @@ const loader = document.getElementById( 'loader' ) as HTMLDivElement;
 const cli = document.getElementById( 'cli-output' ) as HTMLPreElement;
 
 drupal.onInstallStarted((): void => {
-    title.innerHTML = 'Installing...'
+    title.innerText = 'Installing...'
     loader.innerHTML = '<div class="cms-installer__loader"></div>'
     status.innerText = 'This might take a minute.';
 });
 
 drupal.onInstallFinished((): void => {
-    title.innerHTML = 'Starting web server...'
+    title.innerText = 'Starting web server...'
     status.innerHTML = '';
 });
 
@@ -23,9 +23,7 @@ drupal.onOutput(( line: string ): void => {
     cli.innerText = line;
 });
 
-window.addEventListener( 'load', async (): Promise<void> => {
-    const url = await drupal.start();
-
+drupal.onStart(( url: string ): void => {
     title.remove();
     loader.remove();
     cli.remove();
@@ -34,8 +32,19 @@ window.addEventListener( 'load', async (): Promise<void> => {
     const wrapper = document.getElementById( 'open' ) as HTMLDivElement;
     wrapper.innerHTML = `<button class="button" type="button">Visit site</button>`;
     // There is no way this query could return null, because we just set the innerHTML.
-    wrapper.querySelector( 'button' )!
-        .addEventListener( 'click', () => {
-            drupal.open( url );
-        });
+    wrapper.querySelector( 'button' )!.addEventListener( 'click', () => {
+        drupal.open( url );
+    });
+});
+
+drupal.onError(( message: string ): void => {
+    title.innerText = 'Uh-oh';
+    status.innerText = 'An error occurred while starting Drupal CMS.';
+    cli.classList.add( 'error' );
+    cli.innerText = message;
+    loader.remove();
+});
+
+window.addEventListener( 'load', (): void => {
+    drupal.start();
 } );

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,4 +1,4 @@
-import Drupal from '../preload/Drupal';
+import { Drupal } from '@/Drupal';
 
 // This is exposed by the preload script.
 declare var drupal: Drupal;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -130,4 +130,9 @@ p {
 
 #cli-output {
   opacity: .4;
+
+  &.error {
+    opacity: 1;
+    color: #b00;
+  }
 }


### PR DESCRIPTION
It's been a long-standing problem that, if an error occurs, you don't know what's happened unless you know to go to the dev tools console and look. That's a pain.

This fixes that outright -- if Composer or PHP encounters a problem during set-up, it's surfaced in the user interface. It's not slick or anything, but it's better than the status quo.