### PR TITLE
Invoke Composer with the included CA bundle

### DIFF
--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -19,10 +19,16 @@ async function createProject ( win?: WebContents ): Promise<void>
     win?.send( Events.InstallStarted );
 
     const runComposer = async ( command: string[] ) => {
-        // We use an unpacked version of Composer because the phar file has a shebang
-        // line that breaks us, due to GUI-launched Electron apps not inheriting the
-        // parent environment in macOS and Linux.
-        command.unshift( path.join( 'composer', 'bin', 'composer' ) );
+        command.unshift(
+            // Use the included CA bundle to avoid issues with outdated certificates
+            // provided by the operating system.
+            '-d',
+            'curl.cainfo=' + path.join( bin, 'cacert.pem' ),
+            // We use an unpacked version of Composer because the phar file has a shebang
+            // line that breaks us, due to GUI-launched Electron apps not inheriting the
+            // parent environment in macOS and Linux.
+            path.join( 'composer', 'bin', 'composer' ),
+        );
 
         const task = execFileAsPromise( path.join( bin, 'php' ), command, {
             // Run from the `bin` directory so we can use a relative path to Composer.


### PR DESCRIPTION
Sentry has been showing us a few errors that include SSL complaints from Composer (via cURL). For example:

```
curl error 60 while downloading https://repo.packagist.org/packages.json: schannel: CertGetCertificateChain trust e rror CERT_TRUST_IS_PARTIAL_CHAIN
```

I'm thinking we should pass the cURL CA bundle to PHP when invoking Composer, so effectively `php -d curl.cainfo=$PATH_TO_OUR_CA_BUNDLE composer/bin/composer ...`

We already call the PHP server this way, specifically to avoid HTTPS issues on Windows -- and indeed, from what I'm seeing in Sentry, Windows is more prone to this. So let's do with Composer what we already do with the PHP server.