### PR TITLE
Log all Composer output to a file for debugging

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -11,3 +11,5 @@ export const projectRoot: string = path.join( app.getPath('documents'), 'drupal'
 export const bin: string = app.isPackaged
     ? path.join( process.resourcesPath, 'bin')
     : path.join( __dirname, '..', '..', 'bin' );
+
+export const installLog: string = path.join( app.getPath( 'temp' ), 'install.log' );


### PR DESCRIPTION
In Sentry, we're seeing that things can most go wrong during the installation process with Composer. That makes sense -- it does 99% of the work of the entire launcher. Unfortunately, Composer's output is pretty long and can get truncated by Sentry, so it'd be better if we could log all the output to a file, which we can ensure is sent to Sentry in a subsequent PR.