### PR TITLE
The build process should check out Composer directly, rather than using the setup-php action

### DIFF
--- a/.github/workflows/app-linux.yml
+++ b/.github/workflows/app-linux.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           chmod +x php
           mv php bin
-          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output ./bin/cacert.pem
+          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output cacert.pem
           yarn run build
           yarn run make
 

--- a/.github/workflows/app-linux.yml
+++ b/.github/workflows/app-linux.yml
@@ -28,11 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          tools: composer
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -55,6 +50,25 @@ jobs:
 #        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
+      - name: Determine latest Composer version
+        id: composer-latest
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: composer/composer
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out latest Composer release
+        uses: actions/checkout@v4
+        with:
+          repository: composer/composer
+          ref: ${{ steps.composer-latest.outputs.release }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: './bin/composer'
+
+      - name: Clean up Composer code base
+        run: rm -r -f .git doc phpstan tests
+        working-directory: './bin/composer'
+
       - name: Download PHP interpreter
         uses: actions/download-artifact@v4
         with:
@@ -62,14 +76,9 @@ jobs:
 
       - name: Create application bundle
         run: |
-          mkdir -p bin
           chmod +x php
           mv php bin
-          cd bin
-          cp $(which composer) composer.phar
-          phar extract -f composer.phar ./composer
-          rm composer.phar
-          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output cacert.pem
+          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output ./bin/cacert.pem
           yarn run build
           yarn run make
 

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           chmod +x php
           mv php bin
-          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output ./bin/cacert.pem
+          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output cacert.pem
           yarn run build
           yarn run make
 

--- a/.github/workflows/app-macos.yml
+++ b/.github/workflows/app-macos.yml
@@ -61,10 +61,6 @@ jobs:
           mkdir -p ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
           cp $PROVISION_PROFILE_PATH ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          tools: composer
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -93,6 +89,25 @@ jobs:
         with:
           name: php-macos
 
+      - name: Determine latest Composer version
+        id: composer-latest
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: composer/composer
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out latest Composer release
+        uses: actions/checkout@v4
+        with:
+          repository: composer/composer
+          ref: ${{ steps.composer-latest.outputs.release }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: './bin/composer'
+
+      - name: Clean up Composer code base
+        run: rm -r -f .git doc phpstan tests
+        working-directory: './bin/composer'
+
       # Only notarize tagged releases; Electron Builder skips notarization if
       # these environment variables are undefined.
       - name: Enable notarization for tagged release
@@ -104,14 +119,9 @@ jobs:
 
       - name: Create application bundle
         run: |
-          mkdir -p bin
           chmod +x php
           mv php bin
-          cd bin
-          cp $(which composer) composer.phar
-          phar extract -f composer.phar ./composer
-          rm composer.phar
-          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output cacert.pem
+          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output ./bin/cacert.pem
           yarn run build
           yarn run make
 

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -57,16 +57,20 @@ jobs:
           repository: composer/composer
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check out latest Composer release
+        uses: actions/checkout@v4
+        with:
+          repository: composer/composer
+          ref: ${{ steps.composer-latest.outputs.release }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: './bin/composer'
+
       - name: Create application bundle
         shell: bash
         run: |
-          echo ${{ steps.composer-latest.release }}
-          mkdir -p bin
+          ls -lR bin
           mv php.exe bin
           cd bin
-          cp $(which composer) composer.phar
-          php.exe /c/tools/php/pharcommand.phar extract -f composer.phar ./composer
-          rm composer.phar
           curl https://curl.haxx.se/ca/cacert.pem --fail --location --output cacert.pem
           yarn run build
           yarn run make

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -66,6 +66,7 @@ jobs:
           path: './bin/composer'
 
       - name: Clean up Composer code base
+        shell: bash
         run: rm -r -f .git doc phpstan tests
         working-directory: './bin/composer'
 

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           mv php.exe bin
-          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output ./bin/cacert.pem
+          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output cacert.pem
           yarn run build
           yarn run make
 

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -65,13 +65,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: './bin/composer'
 
+      - name: Clean up Composer code base
+        run: rm -r -f .git doc phpstan tests
+        working-directory: './bin/composer'
+
       - name: Create application bundle
         shell: bash
         run: |
-          ls -lR bin
           mv php.exe bin
-          cd bin
-          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output cacert.pem
+          curl https://curl.haxx.se/ca/cacert.pem --fail --location --output ./bin/cacert.pem
           yarn run build
           yarn run make
 

--- a/.github/workflows/app-windows.yml
+++ b/.github/workflows/app-windows.yml
@@ -23,11 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          tools: composer
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -55,9 +50,17 @@ jobs:
         with:
           name: php-windows
 
+      - name: Determine latest Composer version
+        id: composer-latest
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: composer/composer
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create application bundle
         shell: bash
         run: |
+          echo ${{ steps.composer-latest.release }}
           mkdir -p bin
           mv php.exe bin
           cd bin

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,7 @@ extraResources:
   # In conjunction with `files` below, ensure that the PHP and Composer executables
   # are in the app's resources directory, not the ASAR archive.
   - 'bin/**'
+  - cacert.pem
   - settings.local.php
 
 files:

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -9,7 +9,10 @@ export const projectRoot: string = path.join(app.getPath('documents'), 'drupal')
 
 // Where additional resources are stored. This varies depending on whether the app has
 // been packaged for release.
-export const resourceDir = app.isPackaged ? process.resourcesPath : app.getAppPath();
+export const resourceDir: string = app.isPackaged ? process.resourcesPath : app.getAppPath();
+
+// The Mozilla CA bundle from cURL.
+export const caBundle: string = path.join(resourceDir, 'cacert.pem');
 
 // Absolute path of the directory with the PHP and Composer binaries.
 export const bin: string = path.join(resourceDir, 'bin');

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -45,7 +45,7 @@ async function createProject (win?: WebContents): Promise<void>
             // Explicitly pass the cURL CA bundle so that HTTPS requests from Composer can
             // succeed on Windows.
             '-d',
-            'curl.cainfo=' + path.join(bin, 'cacert.pem'),
+            `curl.cainfo="${path.join(bin, 'cacert.pem')}"`,
             // We use an unpacked version of Composer because the phar file has a shebang
             // line that breaks us, due to GUI-launched Electron apps not inheriting the
             // parent environment in macOS and Linux.

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -1,4 +1,4 @@
-import { bin, installLog, projectRoot, resourceDir } from './config';
+import { bin, caBundle, installLog, projectRoot, resourceDir } from './config';
 import { Events } from "../Drupal";
 import { type WebContents } from 'electron';
 import { execFile } from 'node:child_process';
@@ -45,7 +45,7 @@ async function createProject (win?: WebContents): Promise<void>
             // Explicitly pass the cURL CA bundle so that HTTPS requests from Composer can
             // succeed on Windows.
             '-d',
-            `curl.cainfo="${path.join(bin, 'cacert.pem')}"`,
+            `curl.cainfo="${caBundle}"`,
             // We use an unpacked version of Composer because the phar file has a shebang
             // line that breaks us, due to GUI-launched Electron apps not inheriting the
             // parent environment in macOS and Linux.

--- a/src/main/php-server.ts
+++ b/src/main/php-server.ts
@@ -1,4 +1,4 @@
-import { projectRoot, bin } from './config';
+import { bin, caBundle, projectRoot } from './config';
 import { default as getPort, portNumbers } from 'get-port';
 import { type ChildProcess, execFile } from 'node:child_process';
 import path from 'node:path';
@@ -10,7 +10,6 @@ export default async (): Promise<{ url: string, serverProcess: ChildProcess }> =
         port: portNumbers(8888, 9999),
     });
     const url = `http://localhost:${port}`;
-    const caFile = path.join(bin, 'cacert.pem');
 
     // Start the built-in PHP web server.
     const serverProcess = execFile(
@@ -18,7 +17,7 @@ export default async (): Promise<{ url: string, serverProcess: ChildProcess }> =
         [
             // Explicitly pass the cURL CA bundle so that HTTPS requests from Drupal can
             // succeed on Windows.
-            '-d', `curl.cainfo="${caFile}"`,
+            '-d', `curl.cainfo="${caBundle}"`,
             '-S', url.substring(7),
             '.ht.router.php',
         ],


### PR DESCRIPTION
This should make our build process a bit faster, since it can just get the current source code from the Composer repository instead of extracting it from the phar file.