### PR TITLE
Add --gtk-version=3 option when launching the executable on Linux, to work around #87

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -38,6 +38,9 @@ files:
   - '!**/src/**'
 
 linux:
+  executableArgs:
+    # Work around https://github.com/drupal/cms-launcher/issues/87
+    - '--gtk-version=3'
   # By default, an AppImage and a snap are built. For the moment, we'll stick with AppImage.
   target: AppImage
 


### PR DESCRIPTION
Tries to fix #87 by implementing the `--gtk-version=3` workaround.