### PR TITLE
The Drupal project is deleted if the server fails to start

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -99,8 +99,10 @@ logger.transports.file.resolvePathFn = (): string => argv.log;
 ipcMain.on(Commands.Start, async ({ sender: win }): Promise<void> => {
     const drupal = new Drupal(argv.root, argv.fixture);
 
+    let installed: boolean = false;
     try {
         await drupal.install(win);
+        installed = true;
 
         // Start the built-in PHP web server and automatically kill it on quit.
         const [url, server] = await drupal.serve(argv.url);
@@ -116,7 +118,9 @@ ipcMain.on(Commands.Start, async ({ sender: win }): Promise<void> => {
         win.send(Events.Error, e);
 
         // Remove unfinished install directory, so installation can be tried again cleanly.
-        await drupal.destroy();
+        if (! installed) {
+            await drupal.destroy();
+        }
     }
     finally {
         // Set up logging to help with debugging auto-update problems, ensure any

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,6 +18,7 @@ interface Options
     log: string;
     composer: string;
     fixture?: string;
+    url?: string;
 }
 
 // If any uncaught exception happens, send it to Sentry.
@@ -63,6 +64,10 @@ const commandLine = yargs().options({
         description: "The path of the Composer PHP script. Don't set this unless you know what you're doing.",
         default: join(binDir, 'composer', 'bin', 'composer'),
     },
+    url: {
+        type: 'string',
+        description: "The URL of the Drupal site. Don't set this unless you know what you're doing.",
+    },
 });
 
 // If in development, allow the Drupal code base to be spun up from a test fixture.
@@ -98,7 +103,7 @@ ipcMain.on(Commands.Start, async ({ sender: win }): Promise<void> => {
         await drupal.install(win);
 
         // Start the built-in PHP web server and automatically kill it on quit.
-        const [url, server] = await drupal.serve();
+        const [url, server] = await drupal.serve(argv.url);
         app.on('will-quit', () => server.kill());
 
         // Let the user know we're up and running.


### PR DESCRIPTION
This is a pretty grievous bug: if the Drupal install succeeds, but the web server fails to start, the Drupal project is still totally deleted because it's in the same try-catch. The tests would have caught this, if we had test coverage of this case. :) I have added a test that fails without the (bad, kludgey) fix I'm adding here.