### PR TITLE
Convert the Drupal class into an event emitter

### DIFF
--- a/src/main/Drupal.ts
+++ b/src/main/Drupal.ts
@@ -57,7 +57,7 @@ export class Drupal extends EventEmitter
         }
     }
 
-    public async start (url?: string): Promise<[string, ChildProcess]>
+    public async start (url?: string): Promise<void>
     {
         try {
             await access(this.root);
@@ -73,7 +73,7 @@ export class Drupal extends EventEmitter
             }
         }
         this.emit(Events.InstallFinished);
-        return this.serve(url);
+        await this.serve(url);
     }
 
     private webRoot (): string
@@ -120,7 +120,7 @@ export class Drupal extends EventEmitter
         await writeFile(filePath, lines.join('\n'));
     }
 
-    private async serve (url?: string): Promise<[string, ChildProcess]>
+    private async serve (url?: string): Promise<void>
     {
         if (typeof url === 'undefined') {
             const port = await getPort({
@@ -134,10 +134,11 @@ export class Drupal extends EventEmitter
                reject('The web server did not start after 3 seconds.');
             }, 3000);
 
-            const onOutput = (line: string, _: any, process: ChildProcess): void => {
+            const onOutput = (line: string, _: any, server: ChildProcess): void => {
                 if (line.includes(`(${url}) started`)) {
                     clearTimeout(timeout);
-                    resolve([url, process]);
+                    this.emit(Events.Started, url, server);
+                    resolve();
                 }
             };
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -99,9 +99,19 @@ logger.transports.file.resolvePathFn = (): string => argv.log;
 ipcMain.on(Commands.Start, async ({ sender: win }): Promise<void> => {
     const drupal = new Drupal(argv.root, argv.fixture);
 
+    drupal.on(Events.InstallStarted, (): void => {
+        win.send(Events.InstallStarted);
+    });
+    drupal.on(Events.Output, (line: string): void => {
+        win.send(Events.Output, line);
+    });
+    drupal.on(Events.InstallFinished, (): void => {
+        win.send(Events.InstallFinished);
+    });
+
     let installed: boolean = false;
     try {
-        await drupal.install(win);
+        await drupal.install();
         installed = true;
 
         // Start the built-in PHP web server and automatically kill it on quit.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -109,13 +109,10 @@ ipcMain.on(Commands.Start, async ({ sender: win }): Promise<void> => {
         win.send(Events.InstallFinished);
     });
 
-    let installed: boolean = false;
     try {
-        await drupal.install();
-        installed = true;
+        const [url, server] = await drupal.start(argv.url);
 
-        // Start the built-in PHP web server and automatically kill it on quit.
-        const [url, server] = await drupal.serve(argv.url);
+        // Automatically kill the server on quit.
         app.on('will-quit', () => server.kill());
 
         // Let the user know we're up and running.
@@ -126,11 +123,6 @@ ipcMain.on(Commands.Start, async ({ sender: win }): Promise<void> => {
         // users to file a GitHub issue.
         Sentry.captureException(e);
         win.send(Events.Error, e);
-
-        // Remove unfinished install directory, so installation can be tried again cleanly.
-        if (! installed) {
-            await drupal.destroy();
-        }
     }
     finally {
         // Set up logging to help with debugging auto-update problems, ensure any

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,6 +20,7 @@ interface Options
     composer: string;
     fixture?: string;
     url?: string;
+    timeout: number;
 }
 
 // If any uncaught exception happens, send it to Sentry.
@@ -68,6 +69,11 @@ const commandLine = yargs().options({
     url: {
         type: 'string',
         description: "The URL of the Drupal site. Don't set this unless you know what you're doing.",
+    },
+    timeout: {
+        type: 'number',
+        description: 'How long to wait for the web server to start before timing out, in seconds.',
+        default: 30,
     },
 });
 
@@ -118,7 +124,7 @@ ipcMain.on(Commands.Start, async ({ sender: win }): Promise<void> => {
     });
 
     try {
-        await drupal.start(argv.url);
+        await drupal.start(argv.url, argv.timeout);
     }
     catch (e) {
         // Send the exception to Sentry so we can analyze it later, without requiring

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -11,6 +11,7 @@ async function launchApp(testInfo: TestInfo, ...options: string[]): Promise<[Ele
         '.',
         `--root=${root}`,
         `--log=${testInfo.outputPath('app.log')}`,
+        `--timeout=2`,
         ...options,
     ],
     env: {
@@ -70,7 +71,7 @@ test("no clean up if server doesn't start", async ({}, testInfo) => {
   const [app, root] = await launchApp(testInfo, '--fixture=basic', '--url=not-a-valid-host');
 
   const window = await app.firstWindow();
-  await expect(window.getByText('The web server did not start after 3 seconds.')).toBeVisible();
+  await expect(window.getByText('The web server did not start after 2 seconds.')).toBeVisible();
 
   // The Drupal root should still exist, because the install succeeded but
   // the server failed to start.


### PR DESCRIPTION
The need to pass the window object into `Drupal.install` is a wart from a much older iteration of this code base. The Drupal class should emit events, and the main process should be responsible for forwarding those on to the renderer.