### PR TITLE
Remove unnecessary tool setup actions from CI workflows for macOS and Windows

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,16 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - if: steps.cache.outputs.cache-hit != 'true'
-        name: "Set up PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          # Install PHP with the tools needed to build the interpreter, if necessary.
-          php-version: latest
-          tools: pecl, composer
-          extensions: curl, openssl, mbstring, tokenizer
-          ini-values: memory_limit=-1
-
       # Cache the built binary so we can skip the build steps if there is a cache hit.
       - name: Generate cache key
         run: |
@@ -91,16 +81,6 @@ jobs:
           path: build
           pattern: php-*
           merge-multiple: true
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          tools: composer
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
 
       - name: Cache dependencies
         id: cache

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,15 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          # Install PHP with the tools needed to build the interpreter, if necessary.
-          php-version: latest
-          tools: pecl, composer
-          extensions: curl, openssl, mbstring, tokenizer
-          ini-values: memory_limit=-1
-
       # Cache the built binary so we can skip the build steps if there is a cache hit.
       - name: Generate cache key
         shell: bash
@@ -60,11 +51,6 @@ jobs:
           # Allows static-php-cli to download its many dependencies more smoothly.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: build
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
 
       - name: Cache dependencies
         id: cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,18 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: latest
-          tools: composer
-          ini-values: memory_limit=-1
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-
       - name: Cache dependencies
         id: cache
         uses: actions/cache@v4


### PR DESCRIPTION
According to the runners' documentation (https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories), the GitHub-hosted runners already have the tooling we need on Windows and macOS, so our use of the setup-php and setup-node actions is redundant.