### PR TITLE
Pre-build the Drupal code base

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -32,6 +32,18 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check out latest tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          # Trick Electron Builder into "re-publishing" this tag.
+          # @see https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/publisher.ts#L47
+          GITHUB_REF_NAME=$(git describe --tags --abbrev=0)
+          git checkout $GITHUB_REF_NAME
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          echo "GITHUB_REF_TYPE=tag" >> $GITHUB_ENV
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -88,7 +100,9 @@ jobs:
       - name: Enable publishing for release branch
         if: github.ref_name == 'main'
         run: |
-          echo "PUBLISH=onTagOrDraft" >> $GITHUB_ENV
+          # Configure Electron Builder to publish.
+          echo "PUBLISH=always" >> $GITHUB_ENV
+
           # Electron Builder needs a token to publish releases.
           echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -88,14 +88,14 @@ jobs:
           fetch-depth: 0
 
       - name: Check out latest tag
-        # if: scheduled
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           # Trick Electron Builder into "re-publishing" this tag.
           # @see https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/publisher.ts#L47
           GITHUB_REF_NAME=$(git describe --tags --abbrev=0)
           git checkout $GITHUB_REF_NAME
-          echo "_GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
-          echo "_GITHUB_REF_TYPE=tag" >> $GITHUB_ENV
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          echo "GGITHUB_REF_TYPE=tag" >> $GITHUB_ENV
 
       - name: Download PHP binaries
         uses: actions/download-artifact@v4
@@ -174,7 +174,7 @@ jobs:
           echo "APPLE_ID=${{ secrets.APPLE_ID }}" >> $GITHUB_ENV
           echo "APPLE_APP_SPECIFIC_PASSWORD=${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}" >> $GITHUB_ENV
           echo "APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> $GITHUB_ENV
-          echo "PUBLISH=onTagOrDraft" >> $GITHUB_ENV
+          echo "PUBLISH=always" >> $GITHUB_ENV
 
           # Electron Builder needs a token to publish releases.
           echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -29,14 +29,14 @@ jobs:
           fetch-depth: 0
 
       - name: Check out latest tag
-        # if: scheduled
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           # Trick Electron Builder into "re-publishing" this tag.
           # @see https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/publisher.ts#L47
           $GITHUB_REF_NAME = git describe --tags --abbrev=0
           git checkout $GITHUB_REF_NAME
-          "_GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $env:GITHUB_ENV
-          "_GITHUB_REF_TYPE=tag" >> $env:GITHUB_ENV
+          "GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $env:GITHUB_ENV
+          "GITHUB_REF_TYPE=tag" >> $env:GITHUB_ENV
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -102,7 +102,7 @@ jobs:
         if: github.ref_name == 'main'
         run: |
           # Configure Electron Builder to publish.
-          "PUBLISH=onTagOrDraft" >> $env:GITHUB_ENV
+          "PUBLISH=always" >> $env:GITHUB_ENV
 
           # Electron Builder needs a token to publish releases.
           "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $env:GITHUB_ENV


### PR DESCRIPTION
As part of #130, I'd like to configure our CI workflows to pre-build the Drupal code base and bundle into into the _existing_ artifacts of the latest tagged release.