### PR TITLE
Explicitly refresh release artifacts when pre-building the Drupal code base

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -38,12 +38,9 @@ jobs:
       - name: Check out latest tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          # Trick Electron Builder into "re-publishing" this tag.
-          # @see https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/publisher.ts#L47
-          GITHUB_REF_NAME=$(git describe --tags --abbrev=0)
-          git checkout $GITHUB_REF_NAME
-          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
-          echo "GITHUB_REF_TYPE=tag" >> $GITHUB_ENV
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          git checkout $LATEST_TAG
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -101,7 +98,7 @@ jobs:
         if: github.ref_name == 'main'
         run: |
           # Configure Electron Builder to publish.
-          echo "PUBLISH=always" >> $GITHUB_ENV
+          echo "PUBLISH=onTagOrDraft" >> $GITHUB_ENV
 
           # Electron Builder needs a token to publish releases.
           echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
@@ -122,3 +119,14 @@ jobs:
           name: app-${{ runner.arch }}
           path: dist/*.AppImage
           retention-days: 7
+
+      - name: Update prebuilt Drupal code base
+        if: ${{ env.LATEST_TAG }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/Drupal_CMS-Linux-arm64.AppImage
+            dist/Drupal_CMS-Linux-x86_64.AppImage
+            dist/latest-linux.yml
+            dist/latest-linux-arm64.yml
+          tag_name: ${{ env.LATEST_TAG }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -90,12 +90,9 @@ jobs:
       - name: Check out latest tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          # Trick Electron Builder into "re-publishing" this tag.
-          # @see https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/publisher.ts#L47
-          GITHUB_REF_NAME=$(git describe --tags --abbrev=0)
-          git checkout $GITHUB_REF_NAME
-          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
-          echo "GITHUB_REF_TYPE=tag" >> $GITHUB_ENV
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          git checkout LATEST_TAG
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Download PHP binaries
         uses: actions/download-artifact@v4
@@ -174,7 +171,7 @@ jobs:
           echo "APPLE_ID=${{ secrets.APPLE_ID }}" >> $GITHUB_ENV
           echo "APPLE_APP_SPECIFIC_PASSWORD=${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}" >> $GITHUB_ENV
           echo "APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> $GITHUB_ENV
-          echo "PUBLISH=always" >> $GITHUB_ENV
+          echo "PUBLISH=onTagOrDraft" >> $GITHUB_ENV
 
           # Electron Builder needs a token to publish releases.
           echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
@@ -196,3 +193,13 @@ jobs:
           name: app
           path: dist/*.zip
           retention-days: 7
+
+      - name: Update prebuilt Drupal code base
+        if: ${{ env.LATEST_TAG }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/Drupal_CMS-macOS.zip
+            dist/Drupal_CMS-macOS.zip.blockmap
+            dist/latest-mac.yml
+          tag_name: ${{ env.LATEST_TAG }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,12 +31,9 @@ jobs:
       - name: Check out latest tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          # Trick Electron Builder into "re-publishing" this tag.
-          # @see https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/publisher.ts#L47
-          $GITHUB_REF_NAME = git describe --tags --abbrev=0
-          git checkout $GITHUB_REF_NAME
-          "GITHUB_REF_NAME=$GITHUB_REF_NAME" >> $env:GITHUB_ENV
-          "GITHUB_REF_TYPE=tag" >> $env:GITHUB_ENV
+          $LATEST_TAG = git describe --tags --abbrev=0
+          git checkout $LATEST_TAG
+          "LATEST_TAG=$LATEST_TAG" >> $env:GITHUB_ENV
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -102,7 +99,7 @@ jobs:
         if: github.ref_name == 'main'
         run: |
           # Configure Electron Builder to publish.
-          "PUBLISH=always" >> $env:GITHUB_ENV
+          "PUBLISH=onTagOrDraft" >> $env:GITHUB_ENV
 
           # Electron Builder needs a token to publish releases.
           "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $env:GITHUB_ENV
@@ -130,3 +127,13 @@ jobs:
           name: app
           path: dist/*.exe
           retention-days: 7
+
+      - name: Update prebuilt Drupal code base
+        if: ${{ env.LATEST_TAG }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/Drupal_CMS-Windows.exe
+            dist/Drupal_CMS-Windows.exe.blockmap
+            dist/latest.yml
+          tag_name: ${{ env.LATEST_TAG }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-launcher",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A quick-start launcher for Drupal CMS.",
   "main": "./out/main/main.js",
   "scripts": {


### PR DESCRIPTION
I had hoped that Electron Builder would overwrite the artifacts in a published release, but it seems that it won't. So we have to change the build workflows to explicitly overwrite existing artifacts if refreshing a tag's build, which seems to be doable by https://github.com/softprops/action-gh-release.