### PR TITLE
Refresh pre-built archives every 6 hours

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -7,6 +7,10 @@ on:
       # PR branches that alter the build process should be prefixed with `build/`, so
       # that this workflow runs.
       - 'build/**'
+  schedule:
+    # Run this workflow every 6 hours to repackage the pre-built Drupal CMS site
+    # with the latest dependencies.
+    - cron: 0 */6 * * *
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,6 +7,10 @@ on:
       # PR branches that alter the build process should be prefixed with `build/`, so
       # that this workflow runs.
       - 'build/**'
+  schedule:
+    # Run this workflow every 6 hours to repackage the pre-built Drupal CMS site
+    # with the latest dependencies.
+    - cron: 0 */6 * * *
   workflow_dispatch:
 
 jobs:
@@ -88,7 +92,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check out latest tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
         run: |
           # Trick Electron Builder into "re-publishing" this tag.
           # @see https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/publisher.ts#L47

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,6 +7,10 @@ on:
       # PR branches that alter the build process should be prefixed with `build/`, so
       # that this workflow runs.
       - 'build/**'
+  schedule:
+    # Run this workflow every 6 hours to repackage the pre-built Drupal CMS site
+    # with the latest dependencies.
+    - cron: 0 */6 * * *
   workflow_dispatch:
 
 # Since only the x64 architecture is supported on Windows, there's only one job to


### PR DESCRIPTION
As the final part of #130, let's ensure our build job runs every 6 hours to refresh the pre-built Drupal code base for the most recent tag and ensure it has the latest dependencies.