### PR TITLE
Record a version number in composer.json

### DIFF
--- a/src/main/ComposerCommand.ts
+++ b/src/main/ComposerCommand.ts
@@ -44,7 +44,7 @@ export class ComposerCommand extends PhpCommand
             // @see https://getcomposer.org/doc/03-cli.md#composer-no-audit
             COMPOSER_NO_AUDIT: '1',
             // Composer doesn't work without COMPOSER_HOME.
-            COMPOSER_HOME: join(app.getPath('home'), '.composer'),
+            COMPOSER_HOME: process.env.COMPOSER_HOME ?? join(app.getPath('home'), '.composer'),
         });
         // An exceptionally generous timeout. No Composer command should take
         // 10 minutes.

--- a/src/main/Drupal.ts
+++ b/src/main/Drupal.ts
@@ -39,6 +39,10 @@ export class Drupal extends EventEmitter
             // Unpack all recipes. This would normally be done during the `create-project` command
             // if dependencies were being installed at that time.
             ['drupal:recipe-unpack'],
+
+            // Record a version number in composer.json so we can update the built project
+            // later if needed.
+            ['config', '--merge', '--json', 'extra.drupal-launcher', '{"version": 1}'],
         ],
 
     }


### PR DESCRIPTION
Fixes #113. This was authored by @mccoyweb, just doing it in a separate PR to avoid inscrutable CI-only test failures unrelated to this change.