### PR TITLE
Docs: Add Windows Firewall troubleshooting guide (Fixes #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This product includes PHP software, freely available from <http://www.php.net/so
 - [How it works](#how-it-works)
 - [Where are the Drupal files and database?](#where-are-the-drupal-files-and-database)
 - [How to uninstall](#how-to-uninstall)
+- [Troubleshooting](#troubleshooting)  <-- ADD THIS LINE
 - [Sponsorship](#sponsorship)
 - [Contributing](#contributing)
 - [Limitations and alternatives](#limitations-and-alternatives)
@@ -56,6 +57,24 @@ To completely uninstall the Drupal CMS Launcher and remove all associated files:
    - Delete the _drupal_ directory to remove the site files and SQLite database.
 
 After these steps, the application and all its data will be fully removed from your system.
+
+## Troubleshooting
+
+This section provides solutions to common problems.
+
+### Windows Defender Firewall is Blocking the Application
+
+On Windows, the built-in firewall may block the launcher because it needs to start a local web server. If the application fails to start or gives a connection error, you may need to manually allow it through the firewall.
+
+**Solution:**
+
+1.  Press the Windows Key, type `Allow an app through Windows Firewall`, and open it.
+2.  Click the **"Change settings"** button. You may need administrator permission.
+3.  Click the **"Allow another app..."** button at the bottom.
+4.  In the new window, click **"Browse..."** and navigate to where you ran the `cms-launcher`. Select the main executable file and click **"Open"**.
+5.  Click the **"Add"** button to add the application to the firewall list.
+6.  You will now see the launcher in the list. Ensure that the checkboxes for **"Private"** and **"Public"** are checked.
+7.  Click **"OK"** to save your changes. The launcher should now be able to connect properly.
 
 ## Sponsorship
 


### PR DESCRIPTION
## Resolves #85

As noted in the issue, new users on Windows can encounter a startup failure if the Windows Firewall blocks the launcher's built-in web server.

---

## Changes
- Added a new **## Troubleshooting** section to the main `README.md`.
- The section provides a clear, step-by-step guide for allowing the application through Windows Firewall.
- Updated the **Table of Contents** for easy navigation to the new section.

---

## How to Test
The changes are purely documentation-based.  

To verify:
1. Review the new **## Troubleshooting** section in the `README.md`.
2. Check for:
   - Clarity  
   - Accuracy  
   - Ease of understanding for new users  
