### PR TITLE
Refactor the Drupal class to remove EventEmitter and make it implement the preloader interface

### DIFF
--- a/src/preload/Drupal.ts
+++ b/src/preload/Drupal.ts
@@ -2,5 +2,5 @@ export interface Drupal
 {
     start: () => void;
 
-    open: (url: string) => void;
+    open: () => void;
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -19,9 +19,9 @@ contextBridge.exposeInMainWorld('drupal', {
         ipcRenderer.send('drupal:start');
     },
 
-    open (url: string): void
+    open (): void
     {
-        ipcRenderer.send('drupal:open', url);
+        ipcRenderer.send('drupal:open');
     },
 
 } as Drupal);

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -9,10 +9,6 @@
     let isWorking: boolean = false;
     let error: boolean = false;
 
-    function open() {
-        drupal.open(url);
-    }
-
     window.addEventListener('message', (event): void => {
         if (event.source === window && event.data === 'port') {
             event.ports[0].onmessage = (event): void => {
@@ -84,7 +80,7 @@
       <p id="status">{@html statusText}</p>
       {#if url}
         <div>
-          <button class="button" type="button" onclick={open}>
+          <button class="button" type="button" onclick={drupal.open}>
             Visit site&nbsp;
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="12" fill="none">
               <path fill="#fff" d="m13.03 6.53-4.5 4.5a.751.751 0 1 1-1.062-1.062l3.22-3.218H1.5a.75.75 0 0 1 0-1.5h9.188L7.469 2.03A.751.751 0 0 1 8.532.967l4.5 4.5a.75.75 0 0 1-.001 1.063Z"/>


### PR DESCRIPTION
This is clean-up and unification. It makes main.ts better scoped as an app initializer and window manager, and lays the foundation for this app to (theoretically) manage multiple Drupal installations at once.