### PR TITLE
Move the app to the /Applications directory on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-launcher",
-  "version": "1.0.0-beta1",
+  "version": "1.0.0-beta2",
   "description": "A quick-start launcher for Drupal CMS.",
   "main": "./out/main/main.js",
   "scripts": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -225,6 +225,10 @@ function createWindow (): void
 }
 
 app.whenReady().then((): void => {
+    // For automatic updates to work, the app needs to be in `/Applications` on macOS.
+    if (process.platform === 'darwin' && app.isPackaged && ! app.isInApplicationsFolder()) {
+        app.moveToApplicationsFolder();
+    }
     createWindow();
 
     app.on('activate', () => {


### PR DESCRIPTION
It turns out that, on Mac, automatic updates to the app can fail if it's in certain spots. It turns out -- although this isn't properly documented anywhere, of course -- that the app needs to be in /Applications to automatically update correctly because downloaded things get quarantined by the operating system.