### PR TITLE
Remove AppImageLauncher from Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This product includes PHP software, freely available from <http://www.php.net/so
 
 * **Windows**: [Download the latest release](https://github.com/drupal/cms-launcher/releases/latest/download/Drupal_CMS-Windows.exe) and double-click to install and run.
 * **macOS**: [Download the latest release](https://github.com/drupal/cms-launcher/releases/latest/download/Drupal_CMS-macOS.zip), unzip it, and move the app to your _Applications_ folder. Then double-click it to run.
-* **Linux**: Install [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher), then [download the latest release](https://github.com/drupal/cms-launcher/releases/latest) of the Drupal CMS Launcher appropriate for your system, right-click file and select "Executable as Program", and double-click it.  
+* **Linux**: [Download the latest release](https://github.com/drupal/cms-launcher/releases/latest) appropriate for your system, right-click and make it executable, and double-click it to run.  
     **Tip**: Use the `arch` or `dpkg --print-architecture` command to check what kind of system you have. If you get `x86_64` or `amd64`, use the `x64` version. If you get `aarch64`, use the `arm64` version.
 
 This app is actively developed, so if you encounter buggy behavior, [please report it](https://github.com/drupal/cms-launcher/issues)!


### PR DESCRIPTION
Remove possibly redundant AppImageLauncher step:

> Install [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher), then [...]

See comment for details:
- https://github.com/drupal/cms-launcher/issues/61#issuecomment-3358361626