### PR TITLE
implement getVersion() method that reads the version from composer.json

### DIFF
--- a/src/main/ComposerCommand.ts
+++ b/src/main/ComposerCommand.ts
@@ -2,6 +2,7 @@ import { app } from 'electron';
 import logger from 'electron-log';
 import { type ExecFileOptions } from 'node:child_process';
 import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
 import { OutputHandler, PhpCommand } from './PhpCommand';
 
 /**
@@ -57,5 +58,17 @@ export class ComposerCommand extends PhpCommand
                 callback(line, ...rest);
             }
         });
+    }
+    // getVersion() method that reads a composer.json file and returns the version field
+    async getVersion (composerJsonPath: string): Promise<string | null>
+    {
+        try {
+            const content = await readFile(composerJsonPath, 'utf-8');
+            const data = JSON.parse(content);
+            return data.version ?? null;
+        } catch (error) {
+            logger.error(Error reading version from ${composerJsonPath}:, error);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
fix #97 

I have made the following chnages in order to implement getVersion():

i) Added getVersion(composerJsonPath: string): Promise<string | null> (async).
ii) Uses await readFile(...) and JSON.parse to extract data.version.
iii) Catches and logs any errors and return null 