### PR TITLE
 fix(Drupal): retrieve version via composer CLI and handle failures

### DIFF
--- a/src/main/Drupal.ts
+++ b/src/main/Drupal.ts
@@ -286,4 +286,21 @@ export class Drupal implements DrupalInterface
                 .start({ cwd: this.webRoot() }, checkForServerStart);
         });
     }
+
+private async getVersion(): Promise<number | null> {
+  try {
+    const { stdout=''} = await new ComposerCommand('config','extra.drupal-launcher.version')
+      .inDirectory(this.root)
+      .run();
+
+    const trimmed = stdout.toString().trim();
+    if (!trimmed) return null;
+
+    const version=parseInt(trimmed, 10);
+    return Number.isNaN(version) ? null : version;
+  } catch (err) {
+    logger.error('Failed to read extra.drupal-launcher.version via composer:', err);
+    return null;
+  }
+}
 }


### PR DESCRIPTION
Fixes #97 

This PR streamlines the changes as assigned:
- Uses `composer config extra.drupal-launcher.version` via ComposerCommand in `src/main/Drupal.ts`.
- Trims stdout and parse with `parseInt(..., 10)`; return `null` for missing/non-numeric values.
- Catches and logs errors; return `null` on failures.

@phenaproxima Sir, Please Review.