### PR TITLE
Refactor the drupal:destroy handler to be invokable, rather than message-based

### DIFF
--- a/src/main/Drupal.ts
+++ b/src/main/Drupal.ts
@@ -106,15 +106,11 @@ export class Drupal
         await shell.openPath(this.root);
     }
 
-    public async destroy (port?: MessagePortMain): Promise<void>
+    public async destroy (): Promise<void>
     {
-        port?.postMessage({ state: 'destroy' });
-
         this.server?.kill();
-        this.server = null;
+        this.url = this.server = null;
         await rm(this.root, { force: true, recursive: true, maxRetries: 3 });
-
-        port?.postMessage({ state: 'clean' });
     }
 
     private webRoot (): string

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -11,6 +11,11 @@ ipcRenderer.on('port', async (event): Promise<void> => {
     window.postMessage('port', '*', event.ports);
 });
 
-contextBridge.exposeInMainWorld('drupal', (command: string): void => {
-    ipcRenderer.send(`drupal:${command}`);
+contextBridge.exposeInMainWorld('drupal', async (command: string): Promise<void> => {
+    if (command === 'start') {
+        ipcRenderer.send(`drupal:${command}`);
+    }
+    else {
+        await ipcRenderer.invoke(`drupal:${command}`);
+    }
 });

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -57,10 +57,13 @@
         }
     });
 
-    function confirmDestroy (): void
+    async function deleteSite (): Promise<void>
     {
         if (confirm($i18n.t('confirm-destroy'))) {
-            drupal('destroy');
+            detail = '';
+            state = 'destroy';
+            await drupal('destroy');
+            state = 'clean';
         }
     }
 
@@ -148,7 +151,7 @@
           <button title={$i18n.t('button.open')} onclick={() => drupal('open')}>
             <FolderIcon width="32" />
           </button>
-          <button title={$i18n.t('button.delete')} onclick={confirmDestroy}>
+          <button title={$i18n.t('button.delete')} onclick={deleteSite}>
             <TrashIcon width="32" />
           </button>
         {:else if state === 'clean'}


### PR DESCRIPTION
The use of a message port to communicate, effectively, UI changes from the main process to the renderer is very, very awkward and needs to be reduced. Unfortunately I had previously gone a pretty fair distance down this wrong path, so I need to refactor all of that out. The easiest one to do that with is the `destroy` handler, so let's start there.