### PR TITLE
Refactor Drupal.extractArchive() to use await consistently

### DIFF
--- a/src/main/Drupal.ts
+++ b/src/main/Drupal.ts
@@ -171,15 +171,18 @@ export class Drupal
 
         // Extract the archive and, regardless of success or failure, stop sending progress
         // information when done.
-        return tar.extract({
-            cwd: this.root,
-            file,
-            onReadEntry: (): void => {
-                done++;
-            },
-        }).finally((): void => {
+        try {
+            await tar.extract({
+                cwd: this.root,
+                file,
+                onReadEntry: (): void => {
+                    done++;
+                },
+            });
+        }
+        finally {
             clearInterval(interval);
-        });
+        }
     }
 
     private async prepareSettings (): Promise<void>


### PR DESCRIPTION
Just a bit of cleanup. When I wrote `Drupal.extractArchive()`, I didn't know you could have a try-finally construct without a `catch` block.