### PR TITLE
Always export configuration outside the web root

### DIFF
--- a/src/main/Drupal.ts
+++ b/src/main/Drupal.ts
@@ -199,6 +199,8 @@ export class Drupal
             return line.startsWith('# ') ? line.substring(2) : line;
         });
         lines.splice(-4, 3, ...replacements);
+        // Export configuration outside the web root.
+        lines.push(`$settings['config_sync_directory'] = '../config';`);
         await writeFile(settingsPath, lines.join('\n'));
 
         // Add the drupal_association_extras module to every install profile. We don't want to

--- a/tests/fixtures/basic/assert-settings.php
+++ b/tests/fixtures/basic/assert-settings.php
@@ -16,3 +16,4 @@ assert($settings['package_manager_allow_direct_write'] === true);
 assert($settings['testing_package_manager'] === true);
 assert(in_array('^localhost$', $settings['trusted_host_patterns'], true));
 assert(getenv('IS_DDEV_PROJECT') === '1');
+assert($settings['config_sync_directory'] === '../config');


### PR DESCRIPTION
It's good practice for configuration to be exported outside the web root, where it can't be easily read by prying eyes. We should set this up by default.