### PR TITLE
Add a button that opens a one-time login link

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -156,6 +156,28 @@ ipcMain.handle('drupal:open', async (): Promise<void> => {
     await shell.openPath(drupal.root);
 });
 
+ipcMain.handle('drupal:login', async (): Promise<void> => {
+    // If the UI is working correctly, it should never be possible to reach this point if
+    // we don't have a URL.
+    assert(typeof drupal.url === 'string');
+
+    const command = [
+        'exec',
+        'drush',
+        '--',
+        'user:login',
+        '--name=admin',
+        `--uri=${drupal.url}`,
+        '--no-browser',
+    ];
+    const { stdout } = await new ComposerCommand(...command).run({
+        cwd: drupal.root,
+    })
+    logger.debug('Generated one-time login link.');
+
+    await shell.openExternal(stdout.toString().trim());
+});
+
 ipcMain.handle('drupal:visit', async (): Promise<void> => {
     // If the UI is working correctly, it should never be possible to reach this point if
     // we don't have a URL.

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -5,7 +5,7 @@
     import ReinstallIcon from '@phosphor-icons/core/regular/arrow-clockwise.svg?component';
     import FolderIcon from '@phosphor-icons/core/regular/folder-open.svg?component';
     import CacheClearIcon from '@phosphor-icons/core/regular/arrows-clockwise.svg?component';
-    import EditIcon from '@phosphor-icons/core/regular/pencil-line.svg?component';
+    import LoginIcon from '@phosphor-icons/core/regular/sign-in.svg?component';
     import i18next from "i18next";
     import { createI18nStore } from "svelte-i18next";
 
@@ -38,7 +38,7 @@
                         clearCache: 'Clear cache',
                         open: 'Open Drupal directory',
                         delete: 'Delete site',
-                        edit: 'Edit site',
+                        login: 'Log in to site',
                         start: 'Start site',
                         visit: 'Visit site',
                     },
@@ -273,8 +273,8 @@
           <button title={$i18n.t('button.open')} onclick={() => drupal('open')}>
             <FolderIcon width="32" />
           </button>
-          <button title={$i18n.t('button.edit')} onclick={login}>
-            <EditIcon width="32" />
+          <button title={$i18n.t('button.login')} onclick={login}>
+            <LoginIcon width="32" />
           </button>
           <button title={$i18n.t('button.delete')} onclick={deleteSite}>
             <TrashIcon width="32" />

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -5,6 +5,7 @@
     import ReinstallIcon from '@phosphor-icons/core/regular/arrow-clockwise.svg?component';
     import FolderIcon from '@phosphor-icons/core/regular/folder-open.svg?component';
     import CacheClearIcon from '@phosphor-icons/core/regular/arrows-clockwise.svg?component';
+    import EditIcon from '@phosphor-icons/core/regular/pencil-line.svg?component';
     import i18next from "i18next";
     import { createI18nStore } from "svelte-i18next";
 
@@ -37,6 +38,7 @@
                         clearCache: 'Clear cache',
                         open: 'Open Drupal directory',
                         delete: 'Delete site',
+                        edit: 'Edit site',
                         start: 'Start site',
                         visit: 'Visit site',
                     },
@@ -178,6 +180,19 @@
         }
     }
 
+    async function login (event: any): Promise<void>
+    {
+        const button = event.currentTarget;
+
+        button.disabled = true;
+        try {
+            await drupal('login');
+        }
+        finally {
+            button.disabled = false;
+        }
+    }
+
     onMount(startDrupal);
 
 </script>
@@ -257,6 +272,9 @@
           </button>
           <button title={$i18n.t('button.open')} onclick={() => drupal('open')}>
             <FolderIcon width="32" />
+          </button>
+          <button title={$i18n.t('button.edit')} onclick={login}>
+            <EditIcon width="32" />
           </button>
           <button title={$i18n.t('button.delete')} onclick={deleteSite}>
             <TrashIcon width="32" />


### PR DESCRIPTION
### Description
Fixes #211.

But I have bad news -- this runs into the infuriating core bug where, if you're already logged in and you use this button, you get shot over to an "access denied" page. Because you're logged in, get it?

Drupal can be so goddamned infuriating sometimes. This is something we could shim around in Drupal CMS Helper, assuming there exists a core issue to correct this annoyance.

Also kind of annoying is that, if you're _not_ logged in, this redirects you to the user edit form, so you can change your password. We could alter that redirect if we were so inclined (for this specific button only), but where should it redirect to?

### AI Disclosure
Nope, wrote this with my human brain.